### PR TITLE
Bugfix: make hw7

### DIFF
--- a/hw07-asm-bignum-addition/Makefile
+++ b/hw07-asm-bignum-addition/Makefile
@@ -6,7 +6,7 @@ hw7setup: hw7.o cppadd128.o
 	$(CXX) hw7.o cppadd128.o -o hw7setup
 
 # the homework is to write add128.s to add two 128 bit numbers
-hw7:  hw7.o add128.s
+hw7:  hw7.o add128.o
 	$(CXX) hw7.o add128.o -o hw7  #link the two .o files together into a program
 hw7.o: hw7.cc
 	$(CXX) -c hw7.cc   # compile only
@@ -17,10 +17,9 @@ cppadd128.o: cppadd128.cc
 	$(CXX) -S cppadd128.cc   # generate the assembler to look at
 
 add128.o: add128.s
-	as add128.s	# run the assembler and generate the .o file
+	as add128.s -o add128.o	# run the assembler and generate the .o file
 
 #note: do not delete add.s, that's your source code!
 #note: deleting *.exe below is under windows.  On linux you must delete hw2 and hw2setup
 clean:
 	rm cppadd128.s *.o *.exe hw7 hw7setup
-


### PR DESCRIPTION
make hw7 depends on add128.o (not .s), add128.o is now actually built

TODO: make hw7setup still generates a bunch of errors on my pi, something with C++ class permissions at first sight